### PR TITLE
don't modify the routing key when delivering

### DIFF
--- a/lib/bunny_mock/exchanges/topic.rb
+++ b/lib/bunny_mock/exchanges/topic.rb
@@ -27,13 +27,13 @@ module BunnyMock
       def deliver(payload, opts, key)
 
         # escape periods with backslash for regex
-        key.gsub!('.', '\.')
+        key = key.gsub('.', '\.')
 
         # replace single wildcards with regex for a single domain
-        key.gsub!(SINGLE_WILDCARD, '(?:\w+)')
+        key = key.gsub(SINGLE_WILDCARD, '(?:\w+)')
 
         # replace multi wildcards with regex for many domains separated by '.'
-        key.gsub!(MULTI_WILDCARD, '\w+\.?')
+        key = key.gsub(MULTI_WILDCARD, '\w+\.?')
 
         # turn key into regex
         key = Regexp.new(key)

--- a/spec/unit/bunny_mock/exchanges/topic_spec.rb
+++ b/spec/unit/bunny_mock/exchanges/topic_spec.rb
@@ -22,10 +22,16 @@ describe BunnyMock::Exchanges::Topic do
 
 			expect(@second.message_count).to eq(1)
 			expect(@second.pop[:message]).to eq('Testing message')
-		end
+    end
+
+    it 'does not modify the routing key' do
+      @source.publish 'Testing message',
+                      routing_key: 'queue.category.sub.first'.freeze
+      expect(message = @first.pop).to_not be_nil
+      expect(message[:options][:routing_key]).to eq('queue.category.sub.first')
+    end
 
 		context 'should deliver with wildcards' do
-
 			it 'for single wildcards' do
 				@source.publish 'Testing message', routing_key: 'queue.*.sub.*'
 


### PR DESCRIPTION
When publishing to a topic exchange, the routing key was being modified (see spec).

By the way, thanks for creating this gem. Nice work.