### PR TITLE
Fix exchange test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ it 'should bind exchanges to exchanges' do
 
   source = channel.exchange 'xchg.source'
   receiver = channel.exchange 'xchg.receiver'
+  xchg = channel.exchange 'xchg.test'
 
   receiver.bind source
   expect(receiver.bound_to?(source)).to be_truthy


### PR DESCRIPTION
`xchg` is used in test but was never defined.