### PR TITLE
Added support of Bunny::Queue#subscribe_with(callable, *)

### DIFF
--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -26,9 +26,11 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'rake', '~> 10.5.0'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '= 0.40.0'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rspec', '~> 3.4.0'
+  s.add_development_dependency 'term-ansicolor', '~> 1.3.0'
+  s.add_development_dependency 'tins', '= 1.6.0'
   s.add_development_dependency 'coveralls'
 
   s.files         = `git ls-files`.split "\n"

--- a/lib/bunny_mock/queue.rb
+++ b/lib/bunny_mock/queue.rb
@@ -86,6 +86,22 @@ module BunnyMock
     end
 
     ##
+    # Adds a specific consumer object to the queue (subscribes for message deliveries).
+    #
+    # @param [#call] consumer A subclass of Bunny::Consumer or any callable object
+    # Secondary params are ignored atm.
+    #
+    # @api public
+    #
+    def subscribe_with(consumer, *_args)
+      @consumers ||= []
+      @consumers << consumer
+      yield_consumers
+
+      self
+    end
+
+    ##
     # Bind this queue to an exchange
     #
     # @param [BunnyMock::Exchange,String] exchange Exchange to bind to

--- a/spec/unit/bunny_mock/queue_spec.rb
+++ b/spec/unit/bunny_mock/queue_spec.rb
@@ -174,6 +174,18 @@ describe BunnyMock::Queue do
     end
   end
 
+  context '#subscribe_with' do
+
+    it 'should consume messages delivered' do
+      consumer = proc do |_delivery, _headers, body|
+        expect(body).to eq('test')
+      end
+    
+      @queue.subscribe_with consumer
+      @queue.publish 'test'
+    end
+  end
+
   context '#purge' do
 
     it 'should clear all messages' do


### PR DESCRIPTION
I use this method to delegate message processing to a specific worker class.