### PR TITLE
messages sent to default exchange are delivered if queue exists

### DIFF
--- a/lib/bunny-mock.rb
+++ b/lib/bunny-mock.rb
@@ -16,6 +16,7 @@ require 'bunny_mock/exchanges/direct'
 require 'bunny_mock/exchanges/topic'
 require 'bunny_mock/exchanges/fanout'
 require 'bunny_mock/exchanges/headers'
+require 'bunny_mock/exchanges/default'
 
 ##
 # A mock RabbitMQ client based on Bunny

--- a/lib/bunny_mock/channel.rb
+++ b/lib/bunny_mock/channel.rb
@@ -178,7 +178,7 @@ module BunnyMock
     # @api public
     #
     def default_exchange
-      default no_declare: true
+      self.connection.default_exchange ||= default(no_declare: true)
     end
 
     ##

--- a/lib/bunny_mock/channel.rb
+++ b/lib/bunny_mock/channel.rb
@@ -133,6 +133,10 @@ module BunnyMock
       exchange name, opts.merge(type: :direct)
     end
 
+    def default(opts = {})
+      exchange '', opts.merge(type: :default)
+    end
+
     ##
     # Mocks a topic exchange
     #
@@ -174,7 +178,7 @@ module BunnyMock
     # @api public
     #
     def default_exchange
-      direct '', no_declare: true
+      default no_declare: true
     end
 
     ##

--- a/lib/bunny_mock/exchanges/default.rb
+++ b/lib/bunny_mock/exchanges/default.rb
@@ -1,0 +1,33 @@
+module BunnyMock
+  module Exchanges
+    class Default < BunnyMock::Exchange
+
+      #
+      # API
+      #
+
+      ##
+      # Deliver a message to route with direct key match
+      #
+      # @param [Object] payload Message content
+      # @param [Hash] opts Message properties
+      # @param [String] key Routing key
+      #
+      # @api public
+      #
+      def deliver(payload, opts, key)
+        @routes[key].each { |route| route.publish payload, opts } if @routes[key]
+      end
+
+      def publish(payload, opts = {})
+        if routing_key = opts[:routing_key]
+          if queue = @channel.connection.queues[routing_key]
+            queue.bind(self)
+          end
+        end
+        super
+      end
+
+    end
+  end
+end

--- a/lib/bunny_mock/session.rb
+++ b/lib/bunny_mock/session.rb
@@ -15,6 +15,8 @@ module BunnyMock
     # @return [Hash<String, BunnyMock::Queue>] Queues created by this channel
     attr_reader :queues
 
+    attr_accessor :default_exchange
+
     ##
     # Creates a new {BunnyMock::Session} instance
     #

--- a/spec/unit/bunny_mock/channel_spec.rb
+++ b/spec/unit/bunny_mock/channel_spec.rb
@@ -109,7 +109,7 @@ describe BunnyMock::Channel do
 		it 'should return a nameless direct exchange' do
 			xchg = @channel.default_exchange
 
-			expect(xchg.class).to eq(BunnyMock::Exchanges::Direct)
+			expect(xchg.class).to eq(BunnyMock::Exchanges::Default)
 			expect(xchg.name).to eq('')
 		end
 	end


### PR DESCRIPTION
For issue #24 which I filed.

This implements a solution along the lines of the first that I mention in issue #24. It's possible that other properties that the default exchange has will not be correctly reflected, or that other things may break. All the existing specs pass, with one modification. I haven't commented or added any new specs, but if you want this it accomplishes the one thing I wanted - if you send a message to the default exchange with routing_key an existing queue, it'll be delivered.