### PR TITLE
Allow Session#create_channel to accept additional args

### DIFF
--- a/lib/bunny_mock/session.rb
+++ b/lib/bunny_mock/session.rb
@@ -88,7 +88,7 @@ module BunnyMock
     #
     # @return [BunnyMock::Channel] Channel instance
     # @api public
-    def create_channel(n = nil, _pool_size = 1)
+    def create_channel(n = nil, _pool_size = 1, *_args)
       # raise same error as {Bunny::Session#create_channel}
       raise ArgumentError, 'channel number 0 is reserved in the protocol and cannot be used' if n && n.zero?
 


### PR DESCRIPTION
In https://github.com/ruby-amqp/bunny/pull/382 and https://github.com/ruby-amqp/bunny/pull/437 `Session#create_channel` got some additional arguments. This change allows calling of `create_channel` with additional arguments.