### PR TITLE
Fixed error for bunny 2.6.x that requires stdlib/timeout to be loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rvm:
   - 2.1.8
   - 2.2.4
-  - 2.3.0
+  - 2.3.3
   - jruby-19mode
 
 branches:

--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     s.add_dependency 'amq-protocol', '<= 1.9.2'
     s.add_dependency 'bunny', '1.7.0'
   else
-    s.add_dependency 'bunny', '>= 1.7'
+    s.add_dependency 'bunny', '>= 2.6'
   end
 
   s.add_development_dependency 'rake', '~> 10.5.0'

--- a/lib/bunny-mock.rb
+++ b/lib/bunny-mock.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'bunny_mock/version'
 
+require 'timeout'
 require 'bunny/exceptions'
 require 'amq/protocol/client'
 


### PR DESCRIPTION
I've testing with bunny-mock 1.5 and bunny 2.6.3, when loading the bunny/exception class it fails unless you:

require 'timeout'

beforehand.

cheers