### PR TITLE
Add ack and nack support

### DIFF
--- a/lib/bunny-mock.rb
+++ b/lib/bunny-mock.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'bunny_mock/version'
 
+require 'timeout'
 require 'bunny/exceptions'
 require 'amq/protocol/client'
 

--- a/lib/bunny_mock/channel.rb
+++ b/lib/bunny_mock/channel.rb
@@ -261,7 +261,18 @@ module BunnyMock
     # @return nil
     # @api public
     #
-    def acknowledge(*)
+    def ack(*)
+      # noop
+    end
+    alias acknowledge ack
+
+    ##
+    # Does nothing atm.
+    #
+    # @return nil
+    # @api public
+    #
+    def nack(*)
       # noop
     end
 

--- a/lib/bunny_mock/get_response.rb
+++ b/lib/bunny_mock/get_response.rb
@@ -14,11 +14,15 @@ module BunnyMock
     # @return [BunnyMock::Channel] Channel the response is from
     attr_reader :channel
 
+    # @return [BunnyMock::Queue] Queue the response is from
+    attr_reader :queue
+
     # @private
     def initialize(channel, queue, opts = {})
       @channel = channel
+      @queue = queue
       @hash = {
-        delivery_tag: '',
+        delivery_tag: self.class.next_delivery_tag,
         redelivered:  false,
         exchange:     opts.fetch(:exchange, ''),
         routing_key:  opts.fetch(:routing_key, queue.name)
@@ -71,6 +75,12 @@ module BunnyMock
     # @return [String] Routing key this message was published with
     def routing_key
       @hash[:routing_key]
+    end
+
+    # @return [Integer] incrementing numerically value to support `#ack` with multiple=true
+    def self.next_delivery_tag
+      @delivery_tag ||= 0
+      @delivery_tag += 1
     end
   end
 end

--- a/spec/integration/message_acknowledgement_spec.rb
+++ b/spec/integration/message_acknowledgement_spec.rb
@@ -1,0 +1,87 @@
+describe BunnyMock::Channel, 'acknowledgement' do
+  let(:queue) { @channel.queue('test.q') }
+  let(:delivery_tags) { {} }
+
+  context 'when `manual_ack` = true' do
+    before do
+      queue.subscribe(manual_ack: true) do |delivery, _headers, body|
+        delivery_tags[body] = delivery[:delivery_tag]
+      end
+      queue.publish 'Another message on the queue'
+    end
+
+    it 'should allow messages which have been acked to be identified' do
+      queue.publish 'Message to acknowledge'
+      delivery_tag = delivery_tags['Message to acknowledge']
+      @channel.ack delivery_tag
+
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag)
+      expect(@channel.acknowledged_state[:acked]).to include(delivery_tag)
+    end
+
+    it 'should allow messages which have not been acked to be identified' do
+      queue.publish 'Message without acknowledgement'
+      delivery_tag = delivery_tags['Message without acknowledgement']
+
+      expect(@channel.acknowledged_state[:pending]).to include(delivery_tag)
+      expect(@channel.acknowledged_state[:acked]).not_to include(delivery_tag)
+    end
+
+    it 'should allow messages which have been nacked to be identified' do
+      queue.publish 'Message to nack'
+      delivery_tag = delivery_tags['Message to nack']
+      @channel.nack delivery_tag
+
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag)
+      expect(@channel.acknowledged_state[:acked]).not_to include(delivery_tag)
+      expect(@channel.acknowledged_state[:nacked]).to include(delivery_tag)
+    end
+
+    it 'should requeue messages with have been nacked with `requeue` = true' do
+      queue.publish 'Message to nack'
+      delivery_tag = delivery_tags['Message to nack']
+      @channel.nack delivery_tag, false, true
+      new_delivery_tag = delivery_tags['Message to nack']
+
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag)
+      expect(@channel.acknowledged_state[:acked]).not_to include(delivery_tag)
+      expect(@channel.acknowledged_state[:nacked]).to include(delivery_tag)
+
+      expect(@channel.acknowledged_state[:pending]).to include(new_delivery_tag)
+    end
+
+    it 'should allow multiple messages to be acked when `multiple` = true' do
+      queue.publish 'Message to be automatically acked'
+      delivery_tag_1 = delivery_tags['Message to be automatically acked']
+      queue.publish 'Message to acked'
+      delivery_tag_2 = delivery_tags['Message to acked']
+      queue.publish 'Message to be left as pending'
+      delivery_tag_3 = delivery_tags['Message to be left as pending']
+
+      @channel.ack delivery_tag_2, true
+
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag_1)
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag_2)
+      expect(@channel.acknowledged_state[:pending]).to include(delivery_tag_3)
+      expect(@channel.acknowledged_state[:acked]).to include(delivery_tag_1)
+      expect(@channel.acknowledged_state[:acked]).to include(delivery_tag_2)
+    end
+
+    it 'should allow multiple messages to be nacked when `multiple` = true' do
+      queue.publish 'Message to be automatically nacked'
+      delivery_tag_1 = delivery_tags['Message to be automatically nacked']
+      queue.publish 'Message to nacked'
+      delivery_tag_2 = delivery_tags['Message to nacked']
+      queue.publish 'Message to be left as pending'
+      delivery_tag_3 = delivery_tags['Message to be left as pending']
+
+      @channel.nack delivery_tag_2, true
+
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag_1)
+      expect(@channel.acknowledged_state[:pending]).not_to include(delivery_tag_2)
+      expect(@channel.acknowledged_state[:pending]).to include(delivery_tag_3)
+      expect(@channel.acknowledged_state[:nacked]).to include(delivery_tag_1)
+      expect(@channel.acknowledged_state[:nacked]).to include(delivery_tag_2)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for Issue https://github.com/arempe93/bunny-mock/issues/18.

This adds tracking of messages via delivery_tag (incrementing Integer) when subscribing with `manual_ack: true`. 

The current state of messages, as well as the details required to requeue them are stored on the channel and can be accessed from `channel.acknowledgement_state`.