### PR TITLE
add generate_consumer_tag to BunnyMock::Channel

### DIFF
--- a/lib/bunny_mock/channel.rb
+++ b/lib/bunny_mock/channel.rb
@@ -103,6 +103,14 @@ module BunnyMock
       @connection.register_exchange xchg_find_or_create(name, opts)
     end
 
+    # Unique string supposed to be used as a consumer tag.
+    #
+    # @return [String]  Unique string.
+    # @api plugin
+    def generate_consumer_tag(name = 'bunny')
+      "#{name}-#{Time.now.to_i * 1000}-#{Kernel.rand(999_999_999_999)}"
+    end
+
     ##
     # Mocks a fanout exchange
     #


### PR DESCRIPTION
I came across an undefined method error at runtime error while using minitest:
<img width="1182" alt="screen shot 2017-05-16 at 12 21 27 am" src="https://cloud.githubusercontent.com/assets/1630090/26094173/b731e0b4-39cd-11e7-94f8-9c22df15d810.png">

**Versions:**
ruby: `2.3.3`
bunny: `2.6.5`
bunny-mock: `1.6.0`

I was able to fix this issue by copying the `generate_consumer_tag` method definition from the `bunny` gem's `Bunny::Channel` class into the `bunny-mock` gem's `Bunny::Channel`.