### PR TITLE
Adding blocked status

### DIFF
--- a/lib/bunny_mock/session.rb
+++ b/lib/bunny_mock/session.rb
@@ -81,6 +81,15 @@ module BunnyMock
     end
 
     ##
+    # Tests if connection is blocked
+    #
+    # @return [Boolean] true if status is blocked, false otherwise
+    # @api public
+    def blocked?
+      @status == :blocked
+    end
+
+    ##
     # Creates a new {BunnyMock::Channel} instance
     #
     # @param [Integer] n Channel identifier

--- a/spec/unit/bunny_mock/session_spec.rb
+++ b/spec/unit/bunny_mock/session_spec.rb
@@ -107,6 +107,16 @@ describe BunnyMock::Session do
     end
   end
 
+  describe "#blocked?" do
+    it 'should always return false' do
+      @session.start
+      expect(@session.blocked?).to be_falsey
+
+      @session.stop
+      expect(@session.blocked?).to be_falsey
+    end
+  end
+
   context '#create_channel (channel)' do
     it 'should create a new channel with no arguments' do
       first = @session.create_channel


### PR DESCRIPTION
In current version of `bunny `, we have a method to check if a `Bunny::Session` is blocked when [RabbitMQ has some issue](http://reference.rubybunny.info/Bunny/Session.html#blocked%3F-instance_method).

I'm adding this method here with `blocked?` always false to have this method in `BunnyMock::Session` too.