### PR TITLE
Fix queue to behave as a queue rather than a stack

### DIFF
--- a/lib/bunny_mock/queue.rb
+++ b/lib/bunny_mock/queue.rb
@@ -263,7 +263,7 @@ module BunnyMock
     def yield_consumers
       @consumers.each do |c, args|
         # rubocop:disable AssignmentInCondition
-        while message = all.pop
+        while message = all.shift
           response = pop_response(message)
           store_acknowledgement(response, args)
           c.call(response)

--- a/spec/unit/bunny_mock/queue_spec.rb
+++ b/spec/unit/bunny_mock/queue_spec.rb
@@ -178,6 +178,17 @@ describe BunnyMock::Queue do
       @queue.publish 'test'
     end
 
+    it 'should consume existing messages in order' do
+      @queue.publish '1'
+      @queue.publish '2'
+      expect {|b|
+        @queue.subscribe(&b)
+      }.to yield_successive_args(
+        [a_value, a_value, '1'],
+        [a_value, a_value, '2'],
+      )
+    end
+
     it 'should create responses with uniq delivery_tags' do
       delivery_tags = []
       @queue.subscribe do |delivery, _headers, _body|


### PR DESCRIPTION
This small change fixes `BunnyMock::Queue#subscribe` so it acts like a queue rather than a stack.