### PR TITLE
Add support for delayed message exchange

### DIFF
--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = BunnyMock::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Andrew Rempe']
-  s.email       = ["616e6472657772656d706540676d61696c2e636f6d"].pack("H*")]
+  s.email       = [["616e6472657772656d706540676d61696c2e636f6d"].pack("H*")]
   s.summary     = 'Mocking for the popular Bunny client for RabbitMQ'
   s.description = 'Easy to use mocking for testing the Bunny client for RabbitMQ'
   s.license     = 'MIT'

--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -1,7 +1,6 @@
 #!/usr/bin/env gem build
 # encoding: utf-8
 
-require 'base64'
 require File.expand_path("../lib/bunny_mock/version", __FILE__)
 
 Gem::Specification.new do |s|
@@ -9,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = BunnyMock::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Andrew Rempe']
-  s.email       = [Base64.decode64('YW5kcmV3cmVtcGVAZ21haWwuY29t\n')]
+  s.email       = ["616e6472657772656d706540676d61696c2e636f6d"].pack("H*")]
   s.summary     = 'Mocking for the popular Bunny client for RabbitMQ'
   s.description = 'Easy to use mocking for testing the Bunny client for RabbitMQ'
   s.license     = 'MIT'

--- a/lib/bunny-mock.rb
+++ b/lib/bunny-mock.rb
@@ -17,6 +17,7 @@ require 'bunny_mock/exchanges/direct'
 require 'bunny_mock/exchanges/topic'
 require 'bunny_mock/exchanges/fanout'
 require 'bunny_mock/exchanges/headers'
+require 'bunny_mock/exchanges/x_delayed_message'
 
 ##
 # A mock RabbitMQ client based on Bunny

--- a/lib/bunny_mock/exchange.rb
+++ b/lib/bunny_mock/exchange.rb
@@ -22,7 +22,7 @@ module BunnyMock
         type = opts.fetch :type, :direct
 
         # get needed class type
-        klazz = BunnyMock::Exchanges.const_get type.to_s.capitalize
+        klazz = BunnyMock::Exchanges.const_get type.to_s.gsub('-', '_').camelize(:upper)
 
         # create exchange of desired type
         klazz.new channel, name, type, opts

--- a/lib/bunny_mock/exchanges/x_delayed_message.rb
+++ b/lib/bunny_mock/exchanges/x_delayed_message.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module BunnyMock
+  module Exchanges
+    class XDelayedMessage < BunnyMock::Exchange
+      #
+      # API
+      #
+
+      ##
+      # Deliver a message to route with direct key match
+      #
+      # @param [Object] payload Message content
+      # @param [Hash] opts Message properties
+      # @param [String] key Routing key
+      #
+      # @api public
+      #
+      def deliver(payload, opts, key)
+        @routes[key].each { |route| route.publish payload, opts } if @routes[key]
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using the 
rabbitmq_delayed_message_exchange plugin : https://blog.rabbitmq.com/posts/2015/04/scheduling-messages-with-rabbitmq

Exchanges are defined like this with Bunny:

`exchange = channel.exchange('devices.delayed', type: 'x-delayed-message', durable: true)`

This gave issues with the BunnyMock gem because the type 'x-delayed-message' isn't known as possible type for an exchange.  This pull request adds support for that type.