### PR TITLE
Add basic implementation for mandatory publishes and return handlers

### DIFF
--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -1,7 +1,6 @@
 #!/usr/bin/env gem build
 # encoding: utf-8
 
-require 'base64'
 require File.expand_path("../lib/bunny_mock/version", __FILE__)
 
 Gem::Specification.new do |s|
@@ -9,7 +8,6 @@ Gem::Specification.new do |s|
   s.version     = BunnyMock::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Andrew Rempe']
-  s.email       = [Base64.decode64('YW5kcmV3cmVtcGVAZ21haWwuY29t\n')]
   s.summary     = 'Mocking for the popular Bunny client for RabbitMQ'
   s.description = 'Easy to use mocking for testing the Bunny client for RabbitMQ'
   s.license     = 'MIT'

--- a/lib/bunny-mock.rb
+++ b/lib/bunny-mock.rb
@@ -12,6 +12,7 @@ require 'bunny_mock/session'
 require 'bunny_mock/channel'
 require 'bunny_mock/exchange'
 require 'bunny_mock/queue'
+require 'bunny_mock/consumer'
 
 require 'bunny_mock/exchanges/direct'
 require 'bunny_mock/exchanges/topic'

--- a/lib/bunny_mock/consumer.rb
+++ b/lib/bunny_mock/consumer.rb
@@ -1,0 +1,10 @@
+module BunnyMock
+  class Consumer
+    attr_reader :block, :args
+
+    def initialize(args, block)
+      @args = args
+      @block = block
+    end
+  end
+end

--- a/lib/bunny_mock/consumer.rb
+++ b/lib/bunny_mock/consumer.rb
@@ -1,10 +1,19 @@
 module BunnyMock
   class Consumer
-    attr_reader :block, :args
+    attr_reader :block, :args, :queue
 
-    def initialize(args, block)
+    def initialize(args, queue, block)
       @args = args
+      @queue = queue
       @block = block
+    end
+
+    def cancel
+      current_consumers = queue.instance_variable_get('@consumers')
+      queue.instance_variable_set('@consumers', current_consumers - [self])
+      true
+    rescue Exception
+      false
     end
   end
 end

--- a/lib/bunny_mock/exchange.rb
+++ b/lib/bunny_mock/exchange.rb
@@ -246,7 +246,7 @@ module BunnyMock
     # Takes a block that will be called anytime a message is returned
     # @api publick
     #
-    def on_return=(&block)
+    def on_return(&block)
       @on_return = block
 
       self

--- a/lib/bunny_mock/exchange.rb
+++ b/lib/bunny_mock/exchange.rb
@@ -45,9 +45,6 @@ module BunnyMock
     # @return [Hash] Creation options
     attr_reader :opts
 
-    # @return [Block] Callback when a message cannot be delivered
-    attr_reader :on_return
-
     # @return [Boolean] If the exchange was declared as durable
     attr_reader :durable
     alias durable? durable
@@ -264,8 +261,8 @@ module BunnyMock
 
     # @private
     def handle_return(basic_return, properties, content)
-      if on_return
-        on_return.call(
+      if @on_return
+        @on_return.call(
           basic_return.merge(reply_code: 312, reply_text: 'NO_ROUTE'),
           properties, content
         )

--- a/lib/bunny_mock/exchange.rb
+++ b/lib/bunny_mock/exchange.rb
@@ -45,6 +45,9 @@ module BunnyMock
     # @return [Hash] Creation options
     attr_reader :opts
 
+    # @return [Block] Callback when a message cannot be delivered
+    attr_reader :on_return
+
     # @return [Boolean] If the exchange was declared as durable
     attr_reader :durable
     alias durable? durable
@@ -237,6 +240,18 @@ module BunnyMock
       # noOp
     end
 
+    ##
+    # Register a callback when messages cannot be delivered
+    #
+    # Takes a block that will be called anytime a message is returned
+    # @api publick
+    #
+    def on_return=(&block)
+      @on_return = block
+
+      self
+    end
+
     #
     # Implementation
     #
@@ -245,6 +260,16 @@ module BunnyMock
     def add_route(key, xchg_or_queue)
       @routes[key] ||= []
       @routes[key] << xchg_or_queue
+    end
+
+    # @private
+    def handle_return(basic_return, properties, content)
+      if on_return
+        on_return.call(
+          basic_return.merge(reply_code: 312, reply_text: 'NO_ROUTE'),
+          properties, content
+        )
+      end
     end
 
     # @private

--- a/lib/bunny_mock/exchanges/direct.rb
+++ b/lib/bunny_mock/exchanges/direct.rb
@@ -16,12 +16,10 @@ module BunnyMock
       # @api public
       #
       def deliver(payload, opts, key)
-        if @routes[key]
-          if @routes[key].any?
-            @routes[key].each { |route| route.publish payload, opts }
-          elsif opts.fetch(:mandatory, false)
-            handle_return({ exchange: name, routing_key: key }, opts, payload)
-          end
+        if @routes[key] && @routes[key].any?
+          @routes[key].each { |route| route.publish payload, opts }
+        elsif opts.fetch(:mandatory, false)
+          handle_return({ exchange: name, routing_key: key }, opts, payload)
         end
       end
     end

--- a/lib/bunny_mock/exchanges/direct.rb
+++ b/lib/bunny_mock/exchanges/direct.rb
@@ -16,7 +16,13 @@ module BunnyMock
       # @api public
       #
       def deliver(payload, opts, key)
-        @routes[key].each { |route| route.publish payload, opts } if @routes[key]
+        if @routes[key]
+          if @routes[key].any?
+            @routes[key].each { |route| route.publish payload, opts }
+          elsif opts.fetch(:mandatory, false)
+            handle_return({ exchange: name, routing_key: key }, opts, payload)
+          end
+        end
       end
     end
   end

--- a/lib/bunny_mock/exchanges/fanout.rb
+++ b/lib/bunny_mock/exchanges/fanout.rb
@@ -15,8 +15,12 @@ module BunnyMock
       #
       # @api public
       #
-      def deliver(payload, opts, _key)
-        @routes.values.flatten.each { |destination| destination.publish(payload, opts) }
+      def deliver(payload, opts, key)
+        if @routes.values.flatten.any?
+          @routes.values.flatten.each { |destination| destination.publish(payload, opts) }
+        elsif opts.fetch(:mandatory, false)
+          handle_return({ exchange: name, routing_key: key }, opts, payload)
+        end
       end
     end
   end

--- a/lib/bunny_mock/exchanges/topic.rb
+++ b/lib/bunny_mock/exchanges/topic.rb
@@ -25,7 +25,11 @@ module BunnyMock
       #
       def deliver(payload, opts, key)
         delivery_routes = @routes.dup.keep_if { |route, _| key =~ route_to_regex(route) }
-        delivery_routes.values.flatten.each { |dest| dest.publish(payload, opts) }
+        if delivery_routes.values.flatten.any?
+          delivery_routes.values.flatten.each { |dest| dest.publish(payload, opts) }
+        elsif opts.fetch(:mandatory, false)
+          handle_return({ exchange: name, routing_key: key }, opts, payload)
+        end
       end
 
       private

--- a/lib/bunny_mock/queue.rb
+++ b/lib/bunny_mock/queue.rb
@@ -84,7 +84,7 @@ module BunnyMock
     # @api public
     #
     def subscribe(*args, &block)
-      consumer = BunnyMock::Consumer.new(args, block)
+      consumer = BunnyMock::Consumer.new(args, self, block)
       @consumers << consumer
       yield_consumers
 

--- a/lib/bunny_mock/queue.rb
+++ b/lib/bunny_mock/queue.rb
@@ -84,7 +84,7 @@ module BunnyMock
     # @api public
     #
     def subscribe(*args, &block)
-      @consumers << [block, args]
+      @consumers << BunnyMock::Consumer.new(args, block)
       yield_consumers
 
       self
@@ -261,12 +261,12 @@ module BunnyMock
 
     # @private
     def yield_consumers
-      @consumers.each do |c, args|
+      @consumers.each do |consumer|
         # rubocop:disable AssignmentInCondition
         while message = all.pop
           response = pop_response(message)
-          store_acknowledgement(response, args)
-          c.call(response)
+          store_acknowledgement(response, consumer.args)
+          consumer.block.call(response)
         end
       end
     end

--- a/lib/bunny_mock/queue.rb
+++ b/lib/bunny_mock/queue.rb
@@ -84,10 +84,11 @@ module BunnyMock
     # @api public
     #
     def subscribe(*args, &block)
-      @consumers << BunnyMock::Consumer.new(args, block)
+      consumer = BunnyMock::Consumer.new(args, block)
+      @consumers << consumer
       yield_consumers
 
-      self
+      consumer
     end
 
     ##
@@ -102,7 +103,7 @@ module BunnyMock
       @consumers << [consumer, args]
       yield_consumers
 
-      self
+      consumer
     end
 
     ##


### PR DESCRIPTION
Hi 👋 

I know this is very very very basic (I'm not event mocking a `Bunny::BasicReturn`) but I had the need to test my `on_return` behaviour when publishing messages with a `mandatory: true` option.

It works as is but:
- Would be better to emulate `Bunny`'s `BasicReturn` logic (I couldn't figure out how)
- Could not find where to add some specs for this

Methods added:
- `on_return(&block)` : public method on `Bunny::Exchange` (exact same implementation as `Bunny`)
- `handle_return(basic_return, properties, content)` : private method on `Bunny::Exchange`

Methods updated:
- `deliver` for `Direct`, `Topic`, `Fanout` (`Headers` does not work as intended so I haven't changed anything)
	- If `opts[:mandatory]` is `true` then `deliver` will call `handle_return` to notify that the message could not be delivered.